### PR TITLE
Add chunk-based LRU eviction

### DIFF
--- a/include/ze_util.h
+++ b/include/ze_util.h
@@ -53,6 +53,22 @@ print_g_queue(char *name, GQueue *queue);
 #endif
 
 /**
+ * @brief Prints all elements in a lru chunk GQueue.
+ *
+ * This function assumes that the GQueue stores integers using GINT_TO_POINTER.
+ *
+ * @param queue A pointer to the GQueue to print.
+ */
+void
+print_g_queue_chunk_lru(char *name, GQueue *queue);
+
+#ifdef DEBUG
+#    define print_g_queue_chunk_lru(name, queue) print_g_queue_chunk_lru(name, queue)
+#else
+#    define print_g_queue_chunk_lru(...)
+#endif
+
+/**
  * @brief Generates a buffer filled with random bytes.
  *
  * This function allocates a buffer of the specified size and fills it with

--- a/src/ze_util.c
+++ b/src/ze_util.c
@@ -27,6 +27,16 @@ print_g_queue(char *name, GQueue *queue) {
     puts("");
 }
 
+void
+print_g_queue_chunk_lru(char *name, GQueue *queue) {
+    printf("Printing queue %s: ", name);
+    for (GList *node = queue->head; node != NULL; node = node->next) {
+        struct ze_pair *zp = node->data;
+        printf("(zone=%d, chunk=%d, id=%d, in_use=%s) ", zp->zone, zp->chunk_offset, zp->id, zp->in_use ? "true" : "false");
+    }
+    puts("");
+}
+
 unsigned char *
 generate_random_buffer(size_t size) {
     if (size == 0) {


### PR DESCRIPTION
* Introduce a new ZE_EVICT_CHUNK policy to evict individual chunks
* Store ze_pair pointers in lru_queue / zone_to_lru_map for chunks
* Add ze_chunk_evict() to remove chunks from the tail of the LRU queue and mark them free.
* Modify ze_update_lru() to conditionally update the queue based on zone or chunk eviction policy

This does not yet deal with garbage collection, and rather just does invalidation. We still need to complete garbage collection.