### PR TITLE
Perform FG eviction if needed

### DIFF
--- a/include/zone_state_manager.h
+++ b/include/zone_state_manager.h
@@ -20,6 +20,17 @@ enum zn_zone_condition {
 };
 
 /**
+ * @enum zsm_get_active_zone_error
+ * @brief Error types for zsm_get_active_zone
+ */
+enum zsm_get_active_zone_error {
+    ZSM_GET_ACTIVE_ZONE_SUCCESS = 0,  /**< Success */
+    ZSM_GET_ACTIVE_ZONE_RETRY = 2,    /**< Thread needs to retry later */
+    ZSM_GET_ACTIVE_ZONE_ERROR = 3,    /**< Error occurred */
+    ZSM_GET_ACTIVE_ZONE_EVICT = 4     /**< Thread needs to evict */
+};
+
+/**
  * @struct zn_zone
  * @brief Stores the state of a zone.
  */
@@ -76,7 +87,7 @@ zsm_init(struct zone_state_manager *state, const uint32_t num_zones, const int f
  *  - Increment the corresponding chunk pointer to point to the next free zone
  *  - If chunk pointer reaches the end, move zone to full list
  */
-int
+enum zsm_get_active_zone_error
 zsm_get_active_zone(struct zone_state_manager *state, struct zn_pair *pair);
 
 /** @brief Not yet thought out well, but a function for host-side gc (when we need to relocate a

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ verify_enabled = get_option('verify')
 debug_enabled = get_option('debugging')
 
 # Conditional compiler flags
-cflags = ['-O2']
+cflags = []
 if verify_enabled
     cflags += ['-DVERIFY']
 endif


### PR DESCRIPTION
Return with ZSM_GET_ACTIVE_ZONE_EVICT from zsm_get_active_zone if eviction needed. Do eviction in fg.

Not sure if this is the best solution. Also, concerningly doesn't seem to work right in O2. Wondering if we need a lock around the eviction thread and fg so they don't both end up trying to do it at the same time.