### PR TITLE
Setup profiler

### DIFF
--- a/include/profiling.h
+++ b/include/profiling.h
@@ -1,6 +1,0 @@
-#ifndef PROFILING_H
-#define PROFILING_H
-
-
-
-#endif //PROFILING_H

--- a/include/zncache.h
+++ b/include/zncache.h
@@ -10,6 +10,7 @@
 #include "zone_state_manager.h"
 #include "eviction_policy.h"
 #include "znbackend.h"
+#include "znprofiler.h"
 
 #define MICROSECS_PER_SECOND 1000000
 #define EVICT_SLEEP_US ((long) (0.5 * MICROSECS_PER_SECOND))
@@ -54,7 +55,7 @@ struct zn_cache {
     struct zn_reader reader; /**< Reader structure for tracking workload location. */
     gint *active_readers;    /**< Owning reference of the list of active readers per zone */
 
-
+    struct zn_profiler * profiler; /**< Stores metrics */
 };
 
 /**
@@ -95,7 +96,7 @@ zn_cache_get(struct zn_cache *cache, const uint32_t id, unsigned char *random_bu
 void
 zn_init_cache(struct zn_cache *cache, struct zbd_info *info, size_t chunk_sz, uint64_t zone_cap,
               int fd, enum zn_evict_policy_type policy, enum zn_backend backend, uint32_t* workload_buffer,
-              uint64_t workload_max);
+              uint64_t workload_max, char *metrics_file);
 
 /**
  * @brief Destroys and cleans up a `zn_cache` structure.

--- a/include/znprofiler.h
+++ b/include/znprofiler.h
@@ -2,14 +2,32 @@
 #define PROFILING_H
 
 #include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <glib.h>
 
 #define METRICS_BUFFER_SIZE (1u << 17)  // 2^17 = 131072
 #define PROFILING_INTERVAL_SEC 2
 #define PROFILING_HEADERS "METRIC,VALUES..."
 
+
+struct zn_profiler_metrics {
+    uint32_t count;
+    double value;
+};
+
+#define PROFILING_METRICS 1 // Keep in sync with enum and zn_profiler_metric_names
+enum zn_profiler_tag {
+    ZN_PROFILER_METRIC_GET_LATENCY = 0
+};
+extern char *zn_profiler_metric_names[PROFILING_METRICS]; // (in znprofiler.c)
+
 struct zn_profiler {
     FILE *fp;
     char buffer[METRICS_BUFFER_SIZE];
+    struct zn_profiler_metrics metrics[PROFILING_METRICS];
+    bool realtime;
+    GMutex lock;
 };
 
 /**
@@ -30,8 +48,59 @@ zn_profiler_close(struct zn_profiler *zp);
 
 /**
  * Write metrics to profiler
+ *
+* LOCKED BY CALLEE
  */
 void
 zn_profiler_write(struct zn_profiler *zp, const char *format, ...);
+
+/**
+ * Write all metrics out and reset counters
+ *
+* LOCKED BY CALLEE
+ */
+void
+zn_profiler_write_all_and_reset(struct zn_profiler *zp);
+
+/**
+ * @brief Increments the specified metric's total value and usage count.
+ *
+ * This function adds the provided @p value to the selected metric's
+ * cumulative total in the profiler and increments the metric's usage count
+ * by one.
+ *
+ * LOCKED BY CALLEE
+ *
+ * @param[in,out] zp      Pointer to the profiler structure managing the metrics.
+ * @param[in]     metric  Enum identifier of the metric to update.
+ * @param[in]     value   The amount to add to the metric's current total.
+ */
+void
+zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, uint32_t value);
+
+/**
+* Calls zn_profiler_update_metric if zp not NULL
+*/
+#define ZN_PROFILER_UPDATE(zp, metric, value)    \
+    do {                                    \
+        if ((zp) != NULL) {                \
+            zn_profiler_update_metric((zp), (metric), (value));     \
+        }                                   \
+    } while (0)
+
+/**
+ * @brief Resets the specified metric's value and usage count to zero.
+ *
+ * This function sets both the cumulative value and usage count for the
+ * given metric to zero, clearing any collected data.
+ *
+ * LOCKED BY **CALLER**
+ *
+ * @param[in,out] zp      Pointer to the profiler structure managing the metrics.
+ * @param[in]     metric  Enum identifier of the metric to reset.
+ */
+void
+zn_profiler_reset_metric(struct zn_profiler *zp, enum zn_profiler_tag metric);
+
 
 #endif //PROFILING_H

--- a/include/znprofiler.h
+++ b/include/znprofiler.h
@@ -76,7 +76,7 @@ zn_profiler_write_all_and_reset(struct zn_profiler *zp);
  * @param[in]     value   The amount to add to the metric's current total.
  */
 void
-zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, uint32_t value);
+zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, double value);
 
 /**
 * Calls zn_profiler_update_metric if zp not NULL

--- a/include/znprofiler.h
+++ b/include/znprofiler.h
@@ -1,0 +1,37 @@
+#ifndef PROFILING_H
+#define PROFILING_H
+
+#include <stdio.h>
+
+#define METRICS_BUFFER_SIZE (1u << 17)  // 2^17 = 131072
+#define PROFILING_INTERVAL_SEC 2
+#define PROFILING_HEADERS "METRIC,VALUES..."
+
+struct zn_profiler {
+    FILE *fp;
+    char buffer[METRICS_BUFFER_SIZE];
+};
+
+/**
+ * Initialize the profiler
+ *
+ * @param filename File to output metrics to
+ * @return Profiler or NULL on error
+ */
+struct zn_profiler *
+zn_profiler_init(const char *filename);
+
+/**
+ * Close and flush profiler
+ * @param zp Profiler
+ */
+void
+zn_profiler_close(struct zn_profiler *zp);
+
+/**
+ * Write metrics to profiler
+ */
+void
+zn_profiler_write(struct zn_profiler *zp, const char *format, ...);
+
+#endif //PROFILING_H

--- a/src/cache.c
+++ b/src/cache.c
@@ -126,8 +126,6 @@ zn_init_cache(struct zn_cache *cache, struct zbd_info *info, size_t chunk_sz, ui
     cache->reader.workload_buffer = workload_buffer;
     cache->reader.workload_max = workload_max;
 
-
-
 #ifdef DEBUG
     printf("Initialized cache:\n");
     printf("\tchunk_sz=%lu\n", cache->chunk_sz);
@@ -143,6 +141,7 @@ zn_init_cache(struct zn_cache *cache, struct zbd_info *info, size_t chunk_sz, ui
     zsm_init(&cache->zone_state, cache->nr_zones, fd, zone_cap, chunk_sz,
              cache->max_nr_active_zones, cache->backend);
 
+    cache->profiler = NULL;
     if (metrics_file != NULL) {
         cache->profiler = zn_profiler_init(metrics_file);
         assert(cache->profiler != NULL);

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,7 @@ srcs = files(
     'cache.c',
     'znutil.c',
     'cachemap.c',
-    'profiling.c',
+    'znprofiler.c',
     'zone_state_manager.c',
     'eviction_policy.c',
     'minheap.c',

--- a/src/profiling.c
+++ b/src/profiling.c
@@ -1,5 +1,0 @@
-//
-// Created by john on 3/16/25.
-//
-
-#include "profiling.h"

--- a/src/zncache.c
+++ b/src/zncache.c
@@ -215,7 +215,7 @@ main(int argc, char **argv) {
         assert(workload_max <= _POSIX_SSIZE_MAX && "Can't be greater than this number");
         errno = 0;
         ssize_t bytes_read = read(workload_fd, workload_buffer, workload_sz);
-        if (bytes_read != workload_sz) {
+        if ((size_t)bytes_read != workload_sz) {
             if (errno != 0) {
                 fprintf(stderr, "Couldn't read the workload file: '%s'\n", strerror(errno));
             } else {
@@ -238,9 +238,12 @@ main(int argc, char **argv) {
            "\tBLOCK_ZONE_CAPACITY: %u\n"
            "\tWorker threads: %u\n"
            "\tEviction threads: %u\n"
-           "\tWorkload file: %s\n",           
+           "\tWorkload file: %s\n"
+           "\tMetrics file: %s\n",
            device, (device_type == ZE_BACKEND_ZNS) ? "ZNS" : "Block", chunk_sz,
-           BLOCK_ZONE_CAPACITY, nr_threads, nr_eviction_threads, workload_file != NULL ? workload_file : "Simple generator");
+           BLOCK_ZONE_CAPACITY, nr_threads, nr_eviction_threads,
+           workload_file != NULL ? workload_file : "Simple generator",
+           metrics_file != NULL ? metrics_file : "NO");
 
 #ifdef DEBUG
     printf("\tDEBUG=on\n");
@@ -297,7 +300,7 @@ main(int argc, char **argv) {
     }
 
     struct zn_cache cache = {0};
-    zn_init_cache(&cache, &info, chunk_sz, zone_capacity, fd, EVICTION_POLICY, device_type, workload_buffer, workload_max);
+    zn_init_cache(&cache, &info, chunk_sz, zone_capacity, fd, EVICTION_POLICY, device_type, workload_buffer, workload_max, metrics_file);
 
     GError *error = NULL;
     // Create a thread pool with a maximum of nr_threads

--- a/src/znprofiler.c
+++ b/src/znprofiler.c
@@ -74,7 +74,7 @@ zn_profiler_write_all_and_reset(struct zn_profiler *zp) {
 }
 
 void
-zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, uint32_t value) {
+zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, double value) {
     g_mutex_lock(&zp->lock);
     zp->metrics[metric].value+=value;
     zp->metrics[metric].count++;

--- a/src/znprofiler.c
+++ b/src/znprofiler.c
@@ -1,0 +1,45 @@
+#include <stdlib.h>
+#include <assert.h>
+#include "znprofiler.h"
+
+#include <znutil.h>
+
+struct zn_profiler *
+zn_profiler_init(const char *filename) {
+    assert(filename);
+
+    struct zn_profiler *zp = malloc(sizeof(struct zn_profiler));
+    if (zp == NULL) {
+        return NULL;
+    }
+
+    zp->fp = fopen(filename, "w");
+    if (zp->fp == NULL) {
+        dbg_printf("Failed to open file %s\n", filename);
+        free(zp);
+        return NULL;
+    }
+
+    // Enable buffering
+    setvbuf(zp->fp, zp->buffer, _IOFBF, METRICS_BUFFER_SIZE);
+
+    zn_profiler_write(zp, "%s\n", PROFILING_HEADERS);
+
+    return zp;
+}
+
+void
+zn_profiler_close(struct zn_profiler *zp) {
+    fflush(zp->fp);
+    free(zp);
+}
+
+void
+zn_profiler_write(struct zn_profiler *zp, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+
+    vfprintf(zp->fp, format, args);
+
+    va_end(args);
+}

--- a/src/znprofiler.c
+++ b/src/znprofiler.c
@@ -2,7 +2,12 @@
 #include <assert.h>
 #include "znprofiler.h"
 
+#include <string.h>
 #include <znutil.h>
+
+char *zn_profiler_metric_names[PROFILING_METRICS] = {
+    "GETLATENCY"
+};
 
 struct zn_profiler *
 zn_profiler_init(const char *filename) {
@@ -23,7 +28,13 @@ zn_profiler_init(const char *filename) {
     // Enable buffering
     setvbuf(zp->fp, zp->buffer, _IOFBF, METRICS_BUFFER_SIZE);
 
+    g_mutex_init(&zp->lock);
+
     zn_profiler_write(zp, "%s\n", PROFILING_HEADERS);
+
+    for (uint32_t i = 0; i < PROFILING_METRICS; i++) {
+        zn_profiler_reset_metric(zp, i);
+    }
 
     return zp;
 }
@@ -39,7 +50,34 @@ zn_profiler_write(struct zn_profiler *zp, const char *format, ...) {
     va_list args;
     va_start(args, format);
 
+    g_mutex_lock(&zp->lock);
     vfprintf(zp->fp, format, args);
+    g_mutex_unlock(&zp->lock);
 
     va_end(args);
 }
+
+void
+zn_profiler_reset_metric(struct zn_profiler *zp, enum zn_profiler_tag metric) {
+    zp->metrics[metric].value = 0;
+    zp->metrics[metric].count = 0;
+}
+
+void
+zn_profiler_write_all_and_reset(struct zn_profiler *zp) {
+    for (uint32_t i = 0; i < PROFILING_METRICS; i++) {
+        g_mutex_lock(&zp->lock);
+        fprintf(zp->fp, "%s,%f\n", zn_profiler_metric_names[i], zp->metrics[i].value / zp->metrics[i].count);
+        zn_profiler_reset_metric(zp, i);
+        g_mutex_unlock(&zp->lock);
+    }
+}
+
+void
+zn_profiler_update_metric(struct zn_profiler *zp, enum zn_profiler_tag metric, uint32_t value) {
+    g_mutex_lock(&zp->lock);
+    zp->metrics[metric].value+=value;
+    zp->metrics[metric].count++;
+    g_mutex_unlock(&zp->lock);
+}
+

--- a/tests/chunk_eviction.c
+++ b/tests/chunk_eviction.c
@@ -75,7 +75,7 @@ setup_dev(char *device, struct zn_cache *cfg) {
 
 	zn_init_cache(cfg, &info, CHUNK_SIZE, zone_capacity,
               fd, ZN_EVICT_CHUNK, backend, workload,
-              WORKLOAD_SZ);
+              WORKLOAD_SZ, NULL);
 
     return 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -9,7 +9,7 @@ foreach test_name : project_tests
         meson.project_source_root() + '/src/cache.c',
         meson.project_source_root() + '/src/znutil.c',
         meson.project_source_root() + '/src/cachemap.c',
-        meson.project_source_root() + '/src/profiling.c',
+        meson.project_source_root() + '/src/znprofiler.c',
         meson.project_source_root() + '/src/zone_state_manager.c',
         meson.project_source_root() + '/src/eviction_policy.c',
         meson.project_source_root() + '/src/minheap.c',


### PR DESCRIPTION
Setup profiling API

New metrics added in headers, various datastructures must sync

To add another, update:
* zn_profiler_tag
* zn_profiler_metric_names

https://github.com/johnramsden/ZNWorkload/blob/f3cb03a30faf9bd3d0aaebcc1025941e281fe079/include/znprofiler.h#L19-L23

https://github.com/johnramsden/ZNWorkload/blob/f3cb03a30faf9bd3d0aaebcc1025941e281fe079/src/znprofiler.c#L8-L10

Then measure a relevant metric and call ZN_PROFILER_UPDATE, eg:

https://github.com/johnramsden/ZNWorkload/blob/f3cb03a30faf9bd3d0aaebcc1025941e281fe079/src/zncache.c#L127-L137

Profiling data goes in file set via `-m`

Updated code to use getopts (see flags via `-h`:

```
Usage: ./buildDir/src/zncache <DEVICE> <CHUNK_SZ> <THREADS> [-w workload_file] [-i iterations] [-m metrics_file ] [ -h]
```

Metrics are recorded at the interval set in: 

https://github.com/johnramsden/ZNWorkload/blob/f3cb03a30faf9bd3d0aaebcc1025941e281fe079/include/znprofiler.h#L10 

And they are flushed based on: 

https://github.com/johnramsden/ZNWorkload/blob/f3cb03a30faf9bd3d0aaebcc1025941e281fe079/include/znprofiler.h#L9 

So they may not show up in the file until the workload is done, or a significant amount of time has passed.

In case we want to do real-time metric, we can. We could update immediately, using the same API and disabling the time-based one, I fear this will be very difficult to graph and will be super spiky so I think we won't want to do this unless it's for the purposes of finding our actual tail latency